### PR TITLE
fixed indicators info and hint

### DIFF
--- a/autoload/lightline/coc.vim
+++ b/autoload/lightline/coc.vim
@@ -91,7 +91,7 @@ endfunction
 
 function! s:countSum() abort
   let info = get(b:, 'coc_diagnostic_info', {})
-  return get(info, 'error', 0) + get(info, 'warning', 0)
+  return get(info, 'error', 0) + get(info, 'warning', 0) + get(info, 'hint', 0) + get(info, 'information', 0)
 endfunction
 
 function! s:isHidden()


### PR DESCRIPTION
### Added fixes for hint and info indicators.
With available **hints** or **info**, the **coc-ok** status indicator does not disappear from the panel. **Fixed**.

![lightline-coc](https://user-images.githubusercontent.com/74660910/99667055-7dcb9900-2a74-11eb-8f7d-093962ec9d26.png)
