### PR TITLE
Improve readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Plug 'josa42/vim-lightline-coc'
 ```viml
 let g:lightline = {
   \   'active': {
-  \     left': [[  'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
+  \     'left': [[  'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
   \   }
   \ }
 
@@ -59,7 +59,7 @@ let g:lightline.component_type = {
 
 " Add the components to the lightline:
 let g:lightline.active = {
-  \   left': [[ 'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
+  \   'left': [[ 'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
   \ }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ Plug 'josa42/vim-lightline-coc'
 ```viml
 let g:lightline = {
   \   'active': {
-  \     'left': [[  'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
+  \     'left': [ [ 'mode', 'paste' ],
+  \               [ 'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ],
+  \               [ 'coc_status' ],
+  \               [ 'readonly', 'filename', 'modified' ]]
   \   }
   \ }
 
-" register compoments:
+" Register compoments:
 call lightline#coc#register()
 ```
 
@@ -59,8 +62,11 @@ let g:lightline.component_type = {
 
 " Add the components to the lightline:
 let g:lightline.active = {
-  \   'left': [[ 'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ], [ 'coc_status'  ]]
-  \ }
+  \   'left': [ [ 'mode', 'paste' ],
+  \             [ 'coc_info', 'coc_hints', 'coc_errors', 'coc_warnings', 'coc_ok' ],
+  \             [ 'coc_status' ],
+  \             [ 'readonly', 'filename', 'modified' ]]
+  \   }
 ```
 
 ## Configuration


### PR DESCRIPTION
The current integration examples replace the default lightline configuration. Some people may want this, but a more sensible option is to add to the default configuration rather than replacing it.

Note this also fixes a few typos in issue #6.